### PR TITLE
increase allowed number of registers touched per instruction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "rainbow-rs"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]

--- a/src/asmutils.rs
+++ b/src/asmutils.rs
@@ -153,11 +153,11 @@ impl SideChannelOperands for ArmInsnDetail<'_> {
 }
 
 pub trait SideChannelOperandsValues {
-    fn sca_operands_values<D>(&self, emu: &Unicorn<D>) -> ArrayVec<u64, 8>;
+    fn sca_operands_values<D>(&self, emu: &Unicorn<D>) -> ArrayVec<u64, 16>;
 }
 
 impl SideChannelOperandsValues for Vec<ArmOperand> {
-    fn sca_operands_values<D>(&self, emu: &Unicorn<D>) -> ArrayVec<u64, 8> {
+    fn sca_operands_values<D>(&self, emu: &Unicorn<D>) -> ArrayVec<u64, 16> {
         let mut result = ArrayVec::new();
         for op in self {
             match op.op_type {


### PR DESCRIPTION
on ARM cortex-M4 more than 8 registers can be affected by a single instruction